### PR TITLE
pass ra-core as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
   },
   "homepage": "https://github.com/RancaguaInnova/moleculer-data-provider#readme",
   "dependencies": {
-    "query-string": "^6.8.3",
+    "query-string": "^6.8.3"
+  },
+  "peerDependencies": {
     "ra-core": "^2.9.7"
   },
   "devDependencies": {
@@ -45,6 +47,7 @@
     "jest": "^24.9.0",
     "prettier": "^1.18.2",
     "prettier-standard": "^15.0.1",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "ra-core": "^2.9.7"
   }
 }


### PR DESCRIPTION
to avoid duplication in node_modules & causes a crash in 3.X version of React Admin